### PR TITLE
Correção de cores da tabela A5.5 (Solo Dragon)

### DIFF
--- a/src/styles/color.less
+++ b/src/styles/color.less
@@ -83,3 +83,8 @@
 @cinza-700: #6a6a6b;
 @cinza-800: #59595b;
 @cinza-900: #4d4d4f;
+
+// Solo Dragon Table A5.5
+@solodragon-cinza: #d3d3d4;
+@solodragon-amarelo: #f5e9d3;
+@solo-dragon-azul: #d3e0f5;

--- a/src/styles/color.less
+++ b/src/styles/color.less
@@ -87,4 +87,4 @@
 // Solo Dragon Table A5.5
 @solodragon-cinza: #d3d3d4;
 @solodragon-amarelo: #f5e9d3;
-@solo-dragon-azul: #d3e0f5;
+@solodragon-azul: #d3e0f5;

--- a/src/styles/journal.less
+++ b/src/styles/journal.less
@@ -328,6 +328,20 @@
           }
         }
 
+        // Solo Dragon Table A5.5 Colors
+
+        .bg-solodragon-cinza {
+          background-color: @solodragon-cinza;
+        }
+
+        .bg-solodragon-amarelo {
+          background-color: @solodragon-amarelo;
+        }
+
+        .bg-solodragon-azul {
+          background-color: @solodragon-azul;
+        }
+
         // Monster cards
 
         div.relative {


### PR DESCRIPTION
Corrigido a ausência das cores cinza, amarelo e azul em células da tabela A5.5 do "Apêndice 5: Solo Dragon" no LB2.