### PR TITLE
ci: corrige compatibilidade do release e ignora .DS_Store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 env:
   package_type: system
   node_version: 20
-  fvtt_minimum: 13
-  fvtt_verified: 13
   fvtt_dry_run: false
 
 jobs:
@@ -69,6 +67,8 @@ jobs:
     outputs:
       id: ${{ steps.get_id.outputs.id }}
       version-without-v: ${{ steps.get_version.outputs.version-without-v }}
+      fvtt-minimum: ${{ steps.get_compatibility.outputs.minimum }}
+      fvtt-verified: ${{ steps.get_compatibility.outputs.verified }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -100,6 +100,15 @@ jobs:
           value=$(jq -r '.id' src/${{ env.package_type }}.json)
           echo "id is $value"
           echo "id=$value" >> "$GITHUB_OUTPUT"
+
+      - name: Extract FoundryVTT compatibility
+        id: get_compatibility
+        run: |
+          minimum=$(jq -r '.compatibility.minimum' src/${{ env.package_type }}.json)
+          verified=$(jq -r '.compatibility.verified' src/${{ env.package_type }}.json)
+          echo "compatibility is minimum=$minimum, verified=$verified"
+          echo "minimum=$minimum" >> "$GITHUB_OUTPUT"
+          echo "verified=$verified" >> "$GITHUB_OUTPUT"
 
       - name: Substitute Manifest and Download Links For Versioned Ones
         id: sub_manifest_link_version
@@ -169,8 +178,8 @@ jobs:
                 "manifest": "https://github.com/${{ github.repository }}/releases/download/${{ needs.build.outputs.version-without-v }}/${{ needs.build.outputs.id }}.json",
                 "notes": "https://github.com/${{ github.repository }}/releases/tag/${{ needs.build.outputs.version-without-v }}",
                 "compatibility": {
-                  "minimum": "${{ env.fvtt_minimum }}",
-                  "verified": "${{ env.fvtt_verified }}"
+                  "minimum": "${{ needs.build.outputs.fvtt-minimum }}",
+                  "verified": "${{ needs.build.outputs.fvtt-verified }}"
                 }
               }
             }'

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ dist
 
 # Junit results
 junit.xml
+
+# macOS
+.DS_Store


### PR DESCRIPTION
## O que muda

- **`.github/workflows/release.yml`**: os valores `minimum`/`verified` enviados ao Package Release API do FoundryVTT eram fixos no `env` do workflow (`fvtt_minimum: 13`, `fvtt_verified: 13`) e haviam ficado desatualizados em relação ao `src/system.json`, que já declara `minimum: "13"` e `verified: "14"`. Ou seja, o registro do FoundryVTT vinha recebendo `verified: 13` enquanto o manifesto publicado dizia `14`.
- Agora o job `build` extrai `compatibility.minimum` e `compatibility.verified` do `src/system.json` via `jq`, seguindo o mesmo padrão já usado para extrair o `id` do pacote, e expõe os valores como outputs do job. O job `publish` consome esses outputs em vez de env vars hardcoded, então os dois arquivos não podem mais divergir.
- **`.gitignore`**: adiciona `.DS_Store` (o `junit.xml` já estava ignorado).

## Por que

Evitar que o próximo release reporte ao registro oficial da FoundryVTT uma versão "verified" desatualizada, e evitar que um `.DS_Store` acabe commitado sem querer.

## Teste

- `npm ci`
- `npm run lint`
- `npm run test`
- `npm run build`
- Validação de sintaxe do YAML do workflow