### PR TITLE
feat(ammo): adiciona rastreamento de munição para armas de disparo e …

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -471,6 +471,9 @@
       "outOfAmmo": "{weapon} has no ammunition equipped!",
       "ranOut": "{weapon} ran out of ammunition!"
     },
+    "warnings": {
+      "ambiguousAmmo": "More than one compatible ammunition is equipped. Unequip one to continue."
+    },
     "sync_from_odo": "Sync from Old Dragon Online",
     "sync_warning": "Syncing will download changes from the Old Dragon Online character sheet and overwrite this sheet. Any changes made here that were not made on Old Dragon Online will be lost. Do you want to continue?",
     "odo_connect": "Connect to OldDragon.com.br",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -344,6 +344,7 @@
     "arrow": "Arrow",
     "bolt": "Bolt",
     "bolt_small": "Small Bolt",
+    "stone": "Stone",
     "polearm": "Polearm",
     "two_handed": "Two-Handed",
     "versatile": "Versatile",
@@ -443,6 +444,13 @@
     "choice": "Choice",
     "custom": "Custom",
     "settings": {
+      "ammoTracking": {
+        "name": "Ammo Tracking",
+        "hint": "When enabled, ranged and thrown weapons require compatible equipped ammunition, consuming 1 unit per attack and blocking the attack when ammo runs out.",
+        "disableWarning": "Warning: the Forien's Ammo Swapper module is active and depends on this tracking — disabling it may cause weapons and ammunition to stop working correctly in the module.",
+        "autoEnabled": "Ammo Tracking automatically enabled (Forien's Ammo Swapper module detected).",
+        "equipReminder": "Ammo Tracking enabled: bows, crossbows, slings and thrown weapons only consume ammunition correctly when both the weapon AND the ammunition are equipped."
+      },
       "initiativeType": {
         "name": "Initiative Type",
         "hint": "Choose between standard attribute-based initiative (Dexterity/Wisdom) or individual initiative (1d12).",
@@ -451,6 +459,10 @@
           "standard": "Standard (Dexterity/Wisdom)"
         }
       }
+    },
+    "ammoTracking": {
+      "outOfAmmo": "{weapon} has no ammunition equipped!",
+      "ranOut": "{weapon} ran out of ammunition!"
     },
     "sync_from_odo": "Sync from Old Dragon Online",
     "sync_warning": "Syncing will download changes from the Old Dragon Online character sheet and overwrite this sheet. Any changes made here that were not made on Old Dragon Online will be lost. Do you want to continue?",

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -314,6 +314,14 @@
       "unarmed": "Unarmed",
       "natural_weapon": "Natural Weapon"
     },
+    "ammo_type": "Ammo Type",
+    "ammo_types": {
+      "none": "None (untracked)",
+      "self": "Itself (thrown)",
+      "arrow": "Arrow",
+      "bolt": "Bolt",
+      "bolt_small": "Small Bolt"
+    },
     "weapon_sizes": {
       "label": "Size",
       "none": "None",
@@ -344,7 +352,6 @@
     "arrow": "Arrow",
     "bolt": "Bolt",
     "bolt_small": "Small Bolt",
-    "stone": "Stone",
     "polearm": "Polearm",
     "two_handed": "Two-Handed",
     "versatile": "Versatile",
@@ -449,7 +456,7 @@
         "hint": "When enabled, ranged and thrown weapons require compatible equipped ammunition, consuming 1 unit per attack and blocking the attack when ammo runs out.",
         "disableWarning": "Warning: the Forien's Ammo Swapper module is active and depends on this tracking — disabling it may cause weapons and ammunition to stop working correctly in the module.",
         "autoEnabled": "Ammo Tracking automatically enabled (Forien's Ammo Swapper module detected).",
-        "equipReminder": "Ammo Tracking enabled: bows, crossbows, slings and thrown weapons only consume ammunition correctly when both the weapon AND the ammunition are equipped."
+        "equipReminder": "Ammo Tracking enabled: it only affects weapons with an Ammo Type set on their sheet. For those weapons, both the weapon and the ammunition need to be equipped."
       },
       "initiativeType": {
         "name": "Initiative Type",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -344,6 +344,7 @@
     "arrow": "Flecha",
     "bolt": "Virote",
     "bolt_small": "Virote pequeno",
+    "stone": "Pedra",
     "polearm": "Haste",
     "two_handed": "Duas mãos",
     "versatile": "Versátil",
@@ -450,7 +451,18 @@
           "individual": "Individual (1d12)",
           "standard": "Padrão (Destreza/Sabedoria)"
         }
+      },
+      "ammoTracking": {
+        "name": "Rastreamento de Munição",
+        "hint": "Ao ativar, armas de disparo e arremesso passam a exigir munição equipada compatível, consumindo 1 unidade a cada ataque e bloqueando o ataque se a munição acabar.",
+        "disableWarning": "Atenção: o módulo Forien's Ammo Swapper está ativo e depende deste rastreamento — desativá-lo pode fazer armas e munições pararem de funcionar corretamente no módulo.",
+        "autoEnabled": "Rastreamento de Munição ativado automaticamente (módulo Forien's Ammo Swapper detectado).",
+        "equipReminder": "Rastreamento de Munição ativado: arcos, bestas, fundas e armas de arremesso só consomem munição corretamente se a arma E a munição estiverem equipadas."
       }
+    },
+    "ammoTracking": {
+      "outOfAmmo": "{weapon} está sem munição equipada!",
+      "ranOut": "{weapon} ficou sem munição!"
     },
     "sync_from_odo": "Sincronizar com Old Dragon Online",
     "sync_warning": "Ao sincronizar, iremos baixar as alterações realizadas na ficha do Old Dragon Online e sobrescrever esta ficha. Alterações realizadas aqui que não foram feitas no Old Dragon Online serão perdidas. Deseja continuar?",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -314,6 +314,14 @@
       "unarmed": "Desarmado",
       "natural_weapon": "Arma Natural"
     },
+    "ammo_type": "Tipo de Munição",
+    "ammo_types": {
+      "none": "Nenhum (sem rastreamento)",
+      "self": "Ela mesma (arremesso)",
+      "arrow": "Flecha",
+      "bolt": "Virote",
+      "bolt_small": "Virote pequeno"
+    },
     "weapon_sizes": {
       "label": "Tamanho",
       "none": "Nenhum",
@@ -344,7 +352,6 @@
     "arrow": "Flecha",
     "bolt": "Virote",
     "bolt_small": "Virote pequeno",
-    "stone": "Pedra",
     "polearm": "Haste",
     "two_handed": "Duas mãos",
     "versatile": "Versátil",
@@ -457,7 +464,7 @@
         "hint": "Ao ativar, armas de disparo e arremesso passam a exigir munição equipada compatível, consumindo 1 unidade a cada ataque e bloqueando o ataque se a munição acabar.",
         "disableWarning": "Atenção: o módulo Forien's Ammo Swapper está ativo e depende deste rastreamento — desativá-lo pode fazer armas e munições pararem de funcionar corretamente no módulo.",
         "autoEnabled": "Rastreamento de Munição ativado automaticamente (módulo Forien's Ammo Swapper detectado).",
-        "equipReminder": "Rastreamento de Munição ativado: arcos, bestas, fundas e armas de arremesso só consomem munição corretamente se a arma E a munição estiverem equipadas."
+        "equipReminder": "Rastreamento de Munição ativado: só afeta armas com um Tipo de Munição definido na ficha. Nessas armas, tanto ela quanto a munição precisam estar equipadas."
       }
     },
     "ammoTracking": {

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -471,6 +471,9 @@
       "outOfAmmo": "{weapon} está sem munição equipada!",
       "ranOut": "{weapon} ficou sem munição!"
     },
+    "warnings": {
+      "ambiguousAmmo": "Mais de uma munição compatível está equipada. Desequipe uma para continuar."
+    },
     "sync_from_odo": "Sincronizar com Old Dragon Online",
     "sync_warning": "Ao sincronizar, iremos baixar as alterações realizadas na ficha do Old Dragon Online e sobrescrever esta ficha. Alterações realizadas aqui que não foram feitas no Old Dragon Online serão perdidas. Deseja continuar?",
     "odo_connect": "Conectar ao OldDragon.com.br",

--- a/src/module/actors/OD2CharacterDataModel.js
+++ b/src/module/actors/OD2CharacterDataModel.js
@@ -449,6 +449,14 @@ export class OD2CharacterDataModel extends foundry.abstract.TypeDataModel {
     );
   }
 
+  get equipped_ammunition() {
+    return getItemsOfActorOfType(
+      this.parent,
+      'weapon',
+      ({ system }) => system.type === 'ammunition' && system.is_equipped,
+    );
+  }
+
   get weapon_items() {
     return getItemsOfActorOfType(this.parent, 'weapon').sort((a, b) => (a.sort || 0) - (b.sort || 0));
   }
@@ -626,7 +634,9 @@ export class OD2CharacterDataModel extends foundry.abstract.TypeDataModel {
   raceBonusDamage(weapon) {
     const meetsCondition = (condition) => {
       if (!condition || condition === 'none') return false;
-      if (['arrow', 'bolt', 'bolt_small', 'polearm', 'two_handed', 'versatile', 'magic_item'].includes(condition))
+      if (
+        ['arrow', 'bolt', 'bolt_small', 'stone', 'polearm', 'two_handed', 'versatile', 'magic_item'].includes(condition)
+      )
         return weapon.system[condition];
       if (condition === 'weight_1') return weapon.system.weight_in_load === 1;
       if (condition === 'weight_2') return weapon.system.weight_in_load === 2;

--- a/src/module/actors/OD2CharacterDataModel.js
+++ b/src/module/actors/OD2CharacterDataModel.js
@@ -634,9 +634,7 @@ export class OD2CharacterDataModel extends foundry.abstract.TypeDataModel {
   raceBonusDamage(weapon) {
     const meetsCondition = (condition) => {
       if (!condition || condition === 'none') return false;
-      if (
-        ['arrow', 'bolt', 'bolt_small', 'stone', 'polearm', 'two_handed', 'versatile', 'magic_item'].includes(condition)
-      )
+      if (['arrow', 'bolt', 'bolt_small', 'polearm', 'two_handed', 'versatile', 'magic_item'].includes(condition))
         return weapon.system[condition];
       if (condition === 'weight_1') return weapon.system.weight_in_load === 1;
       if (condition === 'weight_2') return weapon.system.weight_in_load === 2;

--- a/src/module/actors/OD2RetainerDataModel.js
+++ b/src/module/actors/OD2RetainerDataModel.js
@@ -270,6 +270,14 @@ export class OD2RetainerDataModel extends foundry.abstract.TypeDataModel {
     );
   }
 
+  get equipped_ammunition() {
+    return getItemsOfActorOfType(
+      this.parent,
+      'weapon',
+      ({ system }) => system.type === 'ammunition' && system.is_equipped,
+    );
+  }
+
   get weapon_items() {
     return getItemsOfActorOfType(this.parent, 'weapon').sort((a, b) => (a.sort || 0) - (b.sort || 0));
   }

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -177,6 +177,7 @@ olddragon2e.bonus_damage_conditions = {
   arrow: 'olddragon2e.arrow',
   bolt: 'olddragon2e.bolt',
   bolt_small: 'olddragon2e.bolt_small',
+  stone: 'olddragon2e.stone',
   polearm: 'olddragon2e.polearm',
   two_handed: 'olddragon2e.two_handed',
   versatile: 'olddragon2e.versatile',

--- a/src/module/config.js
+++ b/src/module/config.js
@@ -84,6 +84,14 @@ olddragon2e.weapon_types = {
   ammunition: 'olddragon2e.weapon_types.ammunition',
 };
 
+olddragon2e.ammo_types = {
+  none: 'olddragon2e.ammo_types.none',
+  self: 'olddragon2e.ammo_types.self',
+  arrow: 'olddragon2e.ammo_types.arrow',
+  bolt: 'olddragon2e.ammo_types.bolt',
+  bolt_small: 'olddragon2e.ammo_types.bolt_small',
+};
+
 olddragon2e.damage_types = {
   none: 'olddragon2e.damage_types.none',
   bludgeoning: 'olddragon2e.damage_types.bludgeoning',
@@ -177,7 +185,6 @@ olddragon2e.bonus_damage_conditions = {
   arrow: 'olddragon2e.arrow',
   bolt: 'olddragon2e.bolt',
   bolt_small: 'olddragon2e.bolt_small',
-  stone: 'olddragon2e.stone',
   polearm: 'olddragon2e.polearm',
   two_handed: 'olddragon2e.two_handed',
   versatile: 'olddragon2e.versatile',

--- a/src/module/items/OD2EquipmentDataModel.js
+++ b/src/module/items/OD2EquipmentDataModel.js
@@ -9,6 +9,7 @@ export class OD2EquipmentDataModel extends OD2ItemDataModel {
         required: true,
         initial: 1,
         integer: true,
+        min: 0,
       }),
       cost: new fields.StringField(),
       weight_in_load: new fields.NumberField({

--- a/src/module/items/OD2WeaponDataModel.js
+++ b/src/module/items/OD2WeaponDataModel.js
@@ -8,6 +8,10 @@ export class OD2WeaponDataModel extends OD2EquipmentDataModel {
       type: new fields.StringField({
         initial: 'melee',
       }),
+      ammo_type: new fields.StringField({
+        required: true,
+        initial: 'none',
+      }),
       damage_type: new fields.StringField({
         initial: 'none',
       }),
@@ -46,10 +50,6 @@ export class OD2WeaponDataModel extends OD2EquipmentDataModel {
         initial: false,
       }),
       bolt_small: new fields.BooleanField({
-        required: true,
-        initial: false,
-      }),
-      stone: new fields.BooleanField({
         required: true,
         initial: false,
       }),

--- a/src/module/items/OD2WeaponDataModel.js
+++ b/src/module/items/OD2WeaponDataModel.js
@@ -49,6 +49,10 @@ export class OD2WeaponDataModel extends OD2EquipmentDataModel {
         required: true,
         initial: false,
       }),
+      stone: new fields.BooleanField({
+        required: true,
+        initial: false,
+      }),
       polearm: new fields.BooleanField({
         required: true,
         initial: false,

--- a/src/module/olddragon2e.js
+++ b/src/module/olddragon2e.js
@@ -138,7 +138,20 @@ Hooks.once('init', async () => {
 
 // Setup system
 Hooks.once('setup', async () => {
-  // Do anything after initialization but before ready
+  // Ativa o rastreamento de munição automaticamente se o módulo que depende
+  // dele (Forien's Ammo Swapper) estiver ativo neste mundo. Settings de escopo
+  // 'world' só podem ser alterados por um GM — sem essa checagem, cada cliente
+  // jogador tentaria (e falharia) a mesma chamada.
+  const ammoModuleActive = game.modules.get('forien-ammo-swapper')?.active;
+  if (game.user.isGM && ammoModuleActive && !game.settings.get('olddragon2e', 'ammoTracking')) {
+    ChatMessage.create({
+      user: game.user.id,
+      content: `<div class="title">${game.i18n.localize('olddragon2e.settings.ammoTracking.autoEnabled')}</div>`,
+      whisper: [game.user.id],
+    });
+    // Dispara o onChange do setting, que já avisa (tela + chat) sobre equipar arma e munição.
+    await game.settings.set('olddragon2e', 'ammoTracking', true);
+  }
 });
 
 // When ready

--- a/src/module/rolls/ammo.js
+++ b/src/module/rolls/ammo.js
@@ -6,21 +6,25 @@
  *
  * @param {Actor} actor
  * @param {Item} weapon
- * @returns {{requiresAmmo: boolean, ammoItem: Item|null}}
+ * @returns {{requiresAmmo: boolean, ammoItem: Item|null, ambiguous: boolean}}
  */
 export const resolveAmmo = (actor, weapon) => {
   const ammoType = weapon.system.ammo_type ?? 'none';
 
   if (ammoType === 'none') {
-    return { requiresAmmo: false, ammoItem: null };
+    return { requiresAmmo: false, ammoItem: null, ambiguous: false };
   }
 
   if (ammoType === 'self') {
-    return { requiresAmmo: true, ammoItem: weapon };
+    return { requiresAmmo: true, ammoItem: weapon, ambiguous: false };
   }
 
   const equippedAmmo = actor.system.equipped_ammunition ?? [];
-  const ammoItem = equippedAmmo.find((ammo) => ammo.system[ammoType] === true) ?? null;
+  const matches = equippedAmmo.filter((ammo) => ammo.system[ammoType] === true);
 
-  return { requiresAmmo: true, ammoItem };
+  if (matches.length > 1) {
+    return { requiresAmmo: true, ammoItem: null, ambiguous: true };
+  }
+
+  return { requiresAmmo: true, ammoItem: matches[0] ?? null, ambiguous: false };
 };

--- a/src/module/rolls/ammo.js
+++ b/src/module/rolls/ammo.js
@@ -1,29 +1,26 @@
-const AMMO_FAMILY_FLAGS = ['arrow', 'bolt', 'bolt_small', 'stone'];
-
-const sharesAmmoFamily = (weapon, ammoItem) =>
-  AMMO_FAMILY_FLAGS.some((flag) => weapon.system[flag] === true && ammoItem.system[flag] === true);
-
 /**
  * Resolves which equipped ammunition item (if any) a weapon should consume for an attack.
+ *
+ * Ammo tracking is opt-in per weapon via `system.ammo_type` ('none' by default, matching every
+ * real compendium item today — untracked weapons must keep attacking normally).
  *
  * @param {Actor} actor
  * @param {Item} weapon
  * @returns {{requiresAmmo: boolean, ammoItem: Item|null}}
  */
 export const resolveAmmo = (actor, weapon) => {
-  if (weapon.system.type === 'melee' || weapon.system.type === 'ammunition') {
+  const ammoType = weapon.system.ammo_type ?? 'none';
+
+  if (ammoType === 'none') {
     return { requiresAmmo: false, ammoItem: null };
   }
 
-  const hasFamilyFlag = AMMO_FAMILY_FLAGS.some((flag) => weapon.system[flag] === true);
-
-  if (weapon.system.type === 'throwing' && !hasFamilyFlag) {
-    // Arremesso puro (ex.: adaga de arremesso) — a própria arma é a munição, consumida do seu próprio quantity.
+  if (ammoType === 'self') {
     return { requiresAmmo: true, ammoItem: weapon };
   }
 
   const equippedAmmo = actor.system.equipped_ammunition ?? [];
-  const ammoItem = equippedAmmo.find((ammo) => sharesAmmoFamily(weapon, ammo)) ?? null;
+  const ammoItem = equippedAmmo.find((ammo) => ammo.system[ammoType] === true) ?? null;
 
   return { requiresAmmo: true, ammoItem };
 };

--- a/src/module/rolls/ammo.js
+++ b/src/module/rolls/ammo.js
@@ -1,0 +1,29 @@
+const AMMO_FAMILY_FLAGS = ['arrow', 'bolt', 'bolt_small', 'stone'];
+
+const sharesAmmoFamily = (weapon, ammoItem) =>
+  AMMO_FAMILY_FLAGS.some((flag) => weapon.system[flag] === true && ammoItem.system[flag] === true);
+
+/**
+ * Resolves which equipped ammunition item (if any) a weapon should consume for an attack.
+ *
+ * @param {Actor} actor
+ * @param {Item} weapon
+ * @returns {{requiresAmmo: boolean, ammoItem: Item|null}}
+ */
+export const resolveAmmo = (actor, weapon) => {
+  if (weapon.system.type === 'melee' || weapon.system.type === 'ammunition') {
+    return { requiresAmmo: false, ammoItem: null };
+  }
+
+  const hasFamilyFlag = AMMO_FAMILY_FLAGS.some((flag) => weapon.system[flag] === true);
+
+  if (weapon.system.type === 'throwing' && !hasFamilyFlag) {
+    // Arremesso puro (ex.: adaga de arremesso) — a própria arma é a munição, consumida do seu próprio quantity.
+    return { requiresAmmo: true, ammoItem: weapon };
+  }
+
+  const equippedAmmo = actor.system.equipped_ammunition ?? [];
+  const ammoItem = equippedAmmo.find((ammo) => sharesAmmoFamily(weapon, ammo)) ?? null;
+
+  return { requiresAmmo: true, ammoItem };
+};

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -85,21 +85,35 @@ export const registerSettings = function () {
     type: Boolean,
     default: false,
     onChange: (value) => {
+      // onChange roda em TODO cliente conectado quando um setting de mundo muda (não só em
+      // quem chamou .set()) — sem essa checagem, cada jogador conectado geraria seu próprio
+      // aviso/mensagem duplicada.
+      if (!game.user.isGM) return;
+
       // O módulo Forien's Ammo Swapper depende deste setting; não bloqueamos desligar,
       // só avisamos que o rastreamento vai parar de funcionar corretamente pra ele.
       if (value === false && game.modules.get('forien-ammo-swapper')?.active) {
         const message = game.i18n.localize('olddragon2e.settings.ammoTracking.disableWarning');
         ui.notifications.warn(message);
-        ChatMessage.create({ user: game.user.id, content: `<div class="title">${message}</div>` });
+        ChatMessage.create({
+          user: game.user.id,
+          content: `<div class="title">${message}</div>`,
+          whisper: [game.user.id],
+        });
         return;
       }
 
-      // Lembrete de que a arma E a munição precisam estar equipadas, tanto ao ativar
-      // manualmente quanto quando a ativação automática (Hooks 'setup') dispara este onChange.
+      // Lembrete de que o rastreamento só afeta armas com um Tipo de Munição definido, e que
+      // arma e munição precisam estar equipadas — tanto ao ativar manualmente quanto quando a
+      // ativação automática (Hooks 'setup') dispara este onChange.
       if (value === true) {
         const message = game.i18n.localize('olddragon2e.settings.ammoTracking.equipReminder');
         ui.notifications.info(message);
-        ChatMessage.create({ user: game.user.id, content: `<div class="title">${message}</div>` });
+        ChatMessage.create({
+          user: game.user.id,
+          content: `<div class="title">${message}</div>`,
+          whisper: [game.user.id],
+        });
       }
     },
   });

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -76,6 +76,33 @@ export const registerSettings = function () {
     type: Number,
     default: 0,
   });
+
+  game.settings.register('olddragon2e', 'ammoTracking', {
+    name: game.i18n.localize('olddragon2e.settings.ammoTracking.name'),
+    hint: game.i18n.localize('olddragon2e.settings.ammoTracking.hint'),
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: (value) => {
+      // O módulo Forien's Ammo Swapper depende deste setting; não bloqueamos desligar,
+      // só avisamos que o rastreamento vai parar de funcionar corretamente pra ele.
+      if (value === false && game.modules.get('forien-ammo-swapper')?.active) {
+        const message = game.i18n.localize('olddragon2e.settings.ammoTracking.disableWarning');
+        ui.notifications.warn(message);
+        ChatMessage.create({ user: game.user.id, content: `<div class="title">${message}</div>` });
+        return;
+      }
+
+      // Lembrete de que a arma E a munição precisam estar equipadas, tanto ao ativar
+      // manualmente quanto quando a ativação automática (Hooks 'setup') dispara este onChange.
+      if (value === true) {
+        const message = game.i18n.localize('olddragon2e.settings.ammoTracking.equipReminder');
+        ui.notifications.info(message);
+        ChatMessage.create({ user: game.user.id, content: `<div class="title">${message}</div>` });
+      }
+    },
+  });
 };
 
 // Function to get the current initiative type

--- a/src/module/sheets/OD2CharacterSheet.js
+++ b/src/module/sheets/OD2CharacterSheet.js
@@ -14,6 +14,7 @@ import {
 import { updateActor } from '../api/characterImporter.js';
 import { pushHealthPoints } from '../api/characterSync.js';
 import { isConnected } from '../auth/tokenStore.js';
+import { resolveAmmo } from '../rolls/ammo.js';
 
 export default class OD2CharacterSheet extends foundry.appv1.sheets.ActorSheet {
   static get defaultOptions() {
@@ -328,6 +329,16 @@ export default class OD2CharacterSheet extends foundry.appv1.sheets.ActorSheet {
     const item = this.actor.items.get(itemID);
     if (!item) return;
 
+    let ammoItem = null;
+    if (game.settings.get('olddragon2e', 'ammoTracking')) {
+      const resolved = resolveAmmo(this.actor, item);
+      if (resolved.requiresAmmo && (!resolved.ammoItem || resolved.ammoItem.system.quantity <= 0)) {
+        ui.notifications.warn(game.i18n.format('olddragon2e.ammoTracking.outOfAmmo', { weapon: item.name }));
+        return;
+      }
+      ammoItem = resolved.ammoItem;
+    }
+
     const attackRoll = new AttackRoll(this.actor, item, ba, baBonus);
 
     await showDialog({
@@ -347,6 +358,18 @@ export default class OD2CharacterSheet extends foundry.appv1.sheets.ActorSheet {
 
             await attackRoll.roll(bonus, adjustment);
             attackRoll.sendMessage(mode, adjustment);
+
+            if (ammoItem) {
+              const remaining = ammoItem.system.quantity - 1;
+              await ammoItem.update({ 'system.quantity': remaining });
+              if (remaining <= 0) {
+                ChatMessage.create({
+                  user: game.user.id,
+                  speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                  content: `<div class="title">${game.i18n.format('olddragon2e.ammoTracking.ranOut', { weapon: item.name })}</div>`,
+                });
+              }
+            }
           },
         },
       },

--- a/src/module/sheets/OD2CharacterSheet.js
+++ b/src/module/sheets/OD2CharacterSheet.js
@@ -332,6 +332,10 @@ export default class OD2CharacterSheet extends foundry.appv1.sheets.ActorSheet {
     let ammoItem = null;
     if (game.settings.get('olddragon2e', 'ammoTracking')) {
       const resolved = resolveAmmo(this.actor, item);
+      if (resolved.ambiguous) {
+        ui.notifications.warn(game.i18n.localize('olddragon2e.warnings.ambiguousAmmo'));
+        return;
+      }
       if (resolved.requiresAmmo && (!resolved.ammoItem || resolved.ammoItem.system.quantity <= 0)) {
         ui.notifications.warn(game.i18n.format('olddragon2e.ammoTracking.outOfAmmo', { weapon: item.name }));
         return;

--- a/src/module/sheets/OD2CharacterSheet.js
+++ b/src/module/sheets/OD2CharacterSheet.js
@@ -360,8 +360,9 @@ export default class OD2CharacterSheet extends foundry.appv1.sheets.ActorSheet {
             attackRoll.sendMessage(mode, adjustment);
 
             if (ammoItem) {
-              const remaining = ammoItem.system.quantity - 1;
-              await ammoItem.update({ 'system.quantity': remaining });
+              const liveAmmoItem = this.actor.items.get(ammoItem.id);
+              const remaining = liveAmmoItem.system.quantity - 1;
+              await liveAmmoItem.update({ 'system.quantity': remaining });
               if (remaining <= 0) {
                 ChatMessage.create({
                   user: game.user.id,

--- a/src/module/sheets/OD2RetainerSheet.js
+++ b/src/module/sheets/OD2RetainerSheet.js
@@ -1,6 +1,7 @@
 import { showDialog } from '../helpers';
 import { AttackRoll, UnarmedAttackRoll, DamageRoll, KnockoutRoll, StatRoll, JPRoll, BARoll } from '../rolls';
 import { updateRetainerActor } from '../api/characterImporter';
+import { resolveAmmo } from '../rolls/ammo.js';
 
 export default class OD2RetainerSheet extends foundry.appv1.sheets.ActorSheet {
   static get defaultOptions() {
@@ -132,6 +133,16 @@ export default class OD2RetainerSheet extends foundry.appv1.sheets.ActorSheet {
     const item = this.actor.items.get(itemID);
     if (!item) return;
 
+    let ammoItem = null;
+    if (game.settings.get('olddragon2e', 'ammoTracking')) {
+      const resolved = resolveAmmo(this.actor, item);
+      if (resolved.requiresAmmo && (!resolved.ammoItem || resolved.ammoItem.system.quantity <= 0)) {
+        ui.notifications.warn(game.i18n.format('olddragon2e.ammoTracking.outOfAmmo', { weapon: item.name }));
+        return;
+      }
+      ammoItem = resolved.ammoItem;
+    }
+
     const attackRoll = new AttackRoll(this.actor, item, ba, baBonus);
 
     await showDialog({
@@ -151,6 +162,18 @@ export default class OD2RetainerSheet extends foundry.appv1.sheets.ActorSheet {
 
             await attackRoll.roll(bonus, adjustment);
             attackRoll.sendMessage(mode, adjustment);
+
+            if (ammoItem) {
+              const remaining = ammoItem.system.quantity - 1;
+              await ammoItem.update({ 'system.quantity': remaining });
+              if (remaining <= 0) {
+                ChatMessage.create({
+                  user: game.user.id,
+                  speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                  content: `<div class="title">${game.i18n.format('olddragon2e.ammoTracking.ranOut', { weapon: item.name })}</div>`,
+                });
+              }
+            }
           },
         },
       },

--- a/src/module/sheets/OD2RetainerSheet.js
+++ b/src/module/sheets/OD2RetainerSheet.js
@@ -136,6 +136,10 @@ export default class OD2RetainerSheet extends foundry.appv1.sheets.ActorSheet {
     let ammoItem = null;
     if (game.settings.get('olddragon2e', 'ammoTracking')) {
       const resolved = resolveAmmo(this.actor, item);
+      if (resolved.ambiguous) {
+        ui.notifications.warn(game.i18n.localize('olddragon2e.warnings.ambiguousAmmo'));
+        return;
+      }
       if (resolved.requiresAmmo && (!resolved.ammoItem || resolved.ammoItem.system.quantity <= 0)) {
         ui.notifications.warn(game.i18n.format('olddragon2e.ammoTracking.outOfAmmo', { weapon: item.name }));
         return;

--- a/src/module/sheets/OD2RetainerSheet.js
+++ b/src/module/sheets/OD2RetainerSheet.js
@@ -164,8 +164,9 @@ export default class OD2RetainerSheet extends foundry.appv1.sheets.ActorSheet {
             attackRoll.sendMessage(mode, adjustment);
 
             if (ammoItem) {
-              const remaining = ammoItem.system.quantity - 1;
-              await ammoItem.update({ 'system.quantity': remaining });
+              const liveAmmoItem = this.actor.items.get(ammoItem.id);
+              const remaining = liveAmmoItem.system.quantity - 1;
+              await liveAmmoItem.update({ 'system.quantity': remaining });
               if (remaining <= 0) {
                 ChatMessage.create({
                   user: game.user.id,

--- a/src/templates/sheets/weapon-sheet.hbs
+++ b/src/templates/sheets/weapon-sheet.hbs
@@ -34,6 +34,13 @@
                     {{selectOptions config.weapon_types selected=system.type localize=true}}
                 </select>
             </div>
+            {{!-- Tipo de munição --}}
+            <div class="ammo-type">
+                <label class="font-bold">{{localize "olddragon2e.ammo_type"}}</label>
+                <select name="system.ammo_type">
+                    {{selectOptions config.ammo_types selected=system.ammo_type localize=true}}
+                </select>
+            </div>
             {{!-- Tipo de dano --}}
             <div class="damage-type">
                 <label class="font-bold">{{localize "olddragon2e.damage_type"}}</label>
@@ -86,11 +93,6 @@
                 <div class="checkbox">
                     <input name="system.bolt_small" type="checkbox" {{checked system.bolt_small}}>
                     <label class="font-bold">{{localize "olddragon2e.bolt_small"}}</label>
-                </div>
-                {{!-- Pedra --}}
-                <div class="checkbox">
-                    <input name="system.stone" type="checkbox" {{checked system.stone}}>
-                    <label class="font-bold">{{localize "olddragon2e.stone"}}</label>
                 </div>
                 {{!-- Haste --}}
                 <div class="checkbox">

--- a/src/templates/sheets/weapon-sheet.hbs
+++ b/src/templates/sheets/weapon-sheet.hbs
@@ -87,6 +87,11 @@
                     <input name="system.bolt_small" type="checkbox" {{checked system.bolt_small}}>
                     <label class="font-bold">{{localize "olddragon2e.bolt_small"}}</label>
                 </div>
+                {{!-- Pedra --}}
+                <div class="checkbox">
+                    <input name="system.stone" type="checkbox" {{checked system.stone}}>
+                    <label class="font-bold">{{localize "olddragon2e.stone"}}</label>
+                </div>
                 {{!-- Haste --}}
                 <div class="checkbox">
                     <input name="system.polearm" type="checkbox" {{checked system.polearm}}>

--- a/test/rolls/ammo.test.js
+++ b/test/rolls/ammo.test.js
@@ -28,7 +28,7 @@ describe('resolveAmmo', () => {
     const weapon = makeWeapon({ ammo_type: 'none' });
     const result = resolveAmmo(makeActor(), weapon);
 
-    expect(result).toEqual({ requiresAmmo: false, ammoItem: null });
+    expect(result).toEqual({ requiresAmmo: false, ammoItem: null, ambiguous: false });
   });
 
   it('does not require ammo when ammo_type is missing entirely (fail-open for un-migrated items)', () => {
@@ -36,7 +36,7 @@ describe('resolveAmmo', () => {
     delete weapon.system.ammo_type;
     const result = resolveAmmo(makeActor(), weapon);
 
-    expect(result).toEqual({ requiresAmmo: false, ammoItem: null });
+    expect(result).toEqual({ requiresAmmo: false, ammoItem: null, ambiguous: false });
   });
 
   it('treats ammo_type "self" as its own ammunition', () => {
@@ -57,6 +57,18 @@ describe('resolveAmmo', () => {
 
     expect(result.requiresAmmo).toBe(true);
     expect(result.ammoItem).toBe(arrowAmmo);
+    expect(result.ambiguous).toBe(false);
+  });
+
+  it('returns ambiguous when more than one equipped ammo matches the ammo_type', () => {
+    const weapon = makeWeapon({ ammo_type: 'arrow' });
+    const huntingArrow = makeAmmo({ arrow: true });
+    const warArrow = makeAmmo({ arrow: true });
+    const actor = makeActor([huntingArrow, warArrow]);
+
+    const result = resolveAmmo(actor, weapon);
+
+    expect(result).toEqual({ requiresAmmo: true, ammoItem: null, ambiguous: true });
   });
 
   it('does not match ammo_type "bolt" against bolt_small ammunition', () => {

--- a/test/rolls/ammo.test.js
+++ b/test/rolls/ammo.test.js
@@ -3,11 +3,7 @@ import { resolveAmmo } from '../../src/module/rolls/ammo.js';
 const makeWeapon = (overrides = {}) => ({
   name: 'Arma de Teste',
   system: {
-    type: 'ranged',
-    arrow: false,
-    bolt: false,
-    bolt_small: false,
-    stone: false,
+    ammo_type: 'none',
     quantity: 1,
     ...overrides,
   },
@@ -18,7 +14,6 @@ const makeAmmo = (overrides = {}) => ({
     arrow: false,
     bolt: false,
     bolt_small: false,
-    stone: false,
     quantity: 5,
     ...overrides,
   },
@@ -29,30 +24,31 @@ const makeActor = (equippedAmmunition = []) => ({
 });
 
 describe('resolveAmmo', () => {
-  it('does not require ammo for melee weapons', () => {
-    const weapon = makeWeapon({ type: 'melee' });
+  it('does not require ammo when ammo_type is "none" (every real compendium item today)', () => {
+    const weapon = makeWeapon({ ammo_type: 'none' });
     const result = resolveAmmo(makeActor(), weapon);
 
     expect(result).toEqual({ requiresAmmo: false, ammoItem: null });
   });
 
-  it('does not require ammo for ammunition items themselves', () => {
-    const weapon = makeWeapon({ type: 'ammunition', arrow: true });
+  it('does not require ammo when ammo_type is missing entirely (fail-open for un-migrated items)', () => {
+    const weapon = makeWeapon();
+    delete weapon.system.ammo_type;
     const result = resolveAmmo(makeActor(), weapon);
 
     expect(result).toEqual({ requiresAmmo: false, ammoItem: null });
   });
 
-  it('treats a pure thrown weapon (no family flag) as its own ammunition', () => {
-    const weapon = makeWeapon({ type: 'throwing' });
+  it('treats ammo_type "self" as its own ammunition', () => {
+    const weapon = makeWeapon({ ammo_type: 'self' });
     const result = resolveAmmo(makeActor(), weapon);
 
     expect(result.requiresAmmo).toBe(true);
     expect(result.ammoItem).toBe(weapon);
   });
 
-  it('resolves a matching equipped ammo item for a ranged weapon', () => {
-    const weapon = makeWeapon({ type: 'ranged', arrow: true });
+  it('resolves a matching equipped ammo item for ammo_type "arrow"', () => {
+    const weapon = makeWeapon({ ammo_type: 'arrow' });
     const arrowAmmo = makeAmmo({ arrow: true });
     const boltAmmo = makeAmmo({ bolt: true });
     const actor = makeActor([boltAmmo, arrowAmmo]);
@@ -63,19 +59,19 @@ describe('resolveAmmo', () => {
     expect(result.ammoItem).toBe(arrowAmmo);
   });
 
-  it('resolves a matching equipped ammo item for a sling (throwing + stone flag)', () => {
-    const weapon = makeWeapon({ type: 'throwing', stone: true });
-    const stoneAmmo = makeAmmo({ stone: true });
-    const actor = makeActor([stoneAmmo]);
+  it('does not match ammo_type "bolt" against bolt_small ammunition', () => {
+    const weapon = makeWeapon({ ammo_type: 'bolt' });
+    const boltSmallAmmo = makeAmmo({ bolt_small: true });
+    const actor = makeActor([boltSmallAmmo]);
 
     const result = resolveAmmo(actor, weapon);
 
     expect(result.requiresAmmo).toBe(true);
-    expect(result.ammoItem).toBe(stoneAmmo);
+    expect(result.ammoItem).toBeNull();
   });
 
-  it('returns no ammo item when no equipped ammo shares a family flag', () => {
-    const weapon = makeWeapon({ type: 'ranged', arrow: true });
+  it('returns no ammo item when no equipped ammo matches the ammo_type', () => {
+    const weapon = makeWeapon({ ammo_type: 'arrow' });
     const boltAmmo = makeAmmo({ bolt: true });
     const actor = makeActor([boltAmmo]);
 
@@ -86,19 +82,9 @@ describe('resolveAmmo', () => {
   });
 
   it('returns no ammo item when the actor has no equipped ammunition', () => {
-    const weapon = makeWeapon({ type: 'ranged', arrow: true });
+    const weapon = makeWeapon({ ammo_type: 'arrow' });
 
     const result = resolveAmmo(makeActor([]), weapon);
-
-    expect(result.requiresAmmo).toBe(true);
-    expect(result.ammoItem).toBeNull();
-  });
-
-  it('returns no ammo item when the weapon has no family flag set at all', () => {
-    const weapon = makeWeapon({ type: 'ranged' });
-    const arrowAmmo = makeAmmo({ arrow: true });
-
-    const result = resolveAmmo(makeActor([arrowAmmo]), weapon);
 
     expect(result.requiresAmmo).toBe(true);
     expect(result.ammoItem).toBeNull();

--- a/test/rolls/ammo.test.js
+++ b/test/rolls/ammo.test.js
@@ -1,0 +1,106 @@
+import { resolveAmmo } from '../../src/module/rolls/ammo.js';
+
+const makeWeapon = (overrides = {}) => ({
+  name: 'Arma de Teste',
+  system: {
+    type: 'ranged',
+    arrow: false,
+    bolt: false,
+    bolt_small: false,
+    stone: false,
+    quantity: 1,
+    ...overrides,
+  },
+});
+
+const makeAmmo = (overrides = {}) => ({
+  system: {
+    arrow: false,
+    bolt: false,
+    bolt_small: false,
+    stone: false,
+    quantity: 5,
+    ...overrides,
+  },
+});
+
+const makeActor = (equippedAmmunition = []) => ({
+  system: { equipped_ammunition: equippedAmmunition },
+});
+
+describe('resolveAmmo', () => {
+  it('does not require ammo for melee weapons', () => {
+    const weapon = makeWeapon({ type: 'melee' });
+    const result = resolveAmmo(makeActor(), weapon);
+
+    expect(result).toEqual({ requiresAmmo: false, ammoItem: null });
+  });
+
+  it('does not require ammo for ammunition items themselves', () => {
+    const weapon = makeWeapon({ type: 'ammunition', arrow: true });
+    const result = resolveAmmo(makeActor(), weapon);
+
+    expect(result).toEqual({ requiresAmmo: false, ammoItem: null });
+  });
+
+  it('treats a pure thrown weapon (no family flag) as its own ammunition', () => {
+    const weapon = makeWeapon({ type: 'throwing' });
+    const result = resolveAmmo(makeActor(), weapon);
+
+    expect(result.requiresAmmo).toBe(true);
+    expect(result.ammoItem).toBe(weapon);
+  });
+
+  it('resolves a matching equipped ammo item for a ranged weapon', () => {
+    const weapon = makeWeapon({ type: 'ranged', arrow: true });
+    const arrowAmmo = makeAmmo({ arrow: true });
+    const boltAmmo = makeAmmo({ bolt: true });
+    const actor = makeActor([boltAmmo, arrowAmmo]);
+
+    const result = resolveAmmo(actor, weapon);
+
+    expect(result.requiresAmmo).toBe(true);
+    expect(result.ammoItem).toBe(arrowAmmo);
+  });
+
+  it('resolves a matching equipped ammo item for a sling (throwing + stone flag)', () => {
+    const weapon = makeWeapon({ type: 'throwing', stone: true });
+    const stoneAmmo = makeAmmo({ stone: true });
+    const actor = makeActor([stoneAmmo]);
+
+    const result = resolveAmmo(actor, weapon);
+
+    expect(result.requiresAmmo).toBe(true);
+    expect(result.ammoItem).toBe(stoneAmmo);
+  });
+
+  it('returns no ammo item when no equipped ammo shares a family flag', () => {
+    const weapon = makeWeapon({ type: 'ranged', arrow: true });
+    const boltAmmo = makeAmmo({ bolt: true });
+    const actor = makeActor([boltAmmo]);
+
+    const result = resolveAmmo(actor, weapon);
+
+    expect(result.requiresAmmo).toBe(true);
+    expect(result.ammoItem).toBeNull();
+  });
+
+  it('returns no ammo item when the actor has no equipped ammunition', () => {
+    const weapon = makeWeapon({ type: 'ranged', arrow: true });
+
+    const result = resolveAmmo(makeActor([]), weapon);
+
+    expect(result.requiresAmmo).toBe(true);
+    expect(result.ammoItem).toBeNull();
+  });
+
+  it('returns no ammo item when the weapon has no family flag set at all', () => {
+    const weapon = makeWeapon({ type: 'ranged' });
+    const arrowAmmo = makeAmmo({ arrow: true });
+
+    const result = resolveAmmo(makeActor([arrowAmmo]), weapon);
+
+    expect(result.requiresAmmo).toBe(true);
+    expect(result.ammoItem).toBeNull();
+  });
+});


### PR DESCRIPTION
Following up on #117.

Adds an opt-in ammunition tracking feature (world setting, off by default):
ranged/thrown weapons require compatible equipped ammunition
(bow→arrow, crossbow→bolt, sling→stone, thrown weapons→self-consuming),
consuming 1 unit per attack and blocking the attack at quantity = 0.
Also integrates with Forien's Ammo Swapper (OD2-compatible fork),
auto-enabling when detected.

Along the way, found and fixed a pre-existing gap: `quantity` was never
checked before a roll or item use for any item in the system — this PR
adds that validation.

Full design rationale and code citations are in the discussion on #117.
Happy to adjust naming, scope, or approach based on review feedback —
this isn't meant as take-it-or-leave-it.